### PR TITLE
Automatic update of System.Net.NameResolution from 4.0.0 to 4.3.0 in 1 package

### DIFF
--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Automatic update of `System.Net.NameResolution` from 4.0.0 to 4.3.0 in 1 package
NuKeeper has generated an update of `System.Net.NameResolution` from version 4.0.0 to 4.3.0
Updated in 1 file: \src\JustEat.StatsD\JustEat.StatsD.csproj
This is an automated update. Merge only if it passes tests