### PR TITLE
Automatic update of Shouldly from 2.8.2 to 2.8.3 in 1 package

### DIFF
--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.1" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
+    <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Automatic update of `Shouldly` from 2.8.2 to 2.8.3 in 1 package
NuKeeper has generated an update of `Shouldly` from version 2.8.2 to 2.8.3
Updated in 1 file: \src\JustEat.StatsD.Tests\JustEat.StatsD.Tests.csproj
This is an automated update. Merge only if it passes tests