### PR TITLE
Automatic update of Moq from 4.7.1 to 4.7.63 in 1 project

### DIFF
--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Moq" Version="4.7.63" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
Automatic update of `Moq` from 4.7.1 to 4.7.63 in 1 project
NuKeeper has generated an update of `Moq` from version 4.7.1 to 4.7.63
Updated in 1 file: `\src\JustEat.StatsD.Tests\JustEat.StatsD.Tests.csproj`
This is an automated update. Merge only if it passes tests