### PR TITLE
Automatic update of Microsoft.NETCore.Platforms to 1.1.0

### DIFF
--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated an update of `Microsoft.NETCore.Platforms` from `1.0.2` to `1.1.0` in 1 project
One project update:
Updated to `1.1.0` from `1.0.2` in `\src\JustEat.StatsD\JustEat.StatsD.csproj`
This is an automated update. Merge only if it passes tests
