### PR TITLE
Automatic update of System.Diagnostics.TraceSource to 4.3.0

### DIFF
--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -14,7 +14,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />


### PR DESCRIPTION
NuKeeper has generated an update of `System.Diagnostics.TraceSource` from `4.0.0` to `4.3.0`
One project update:
Updated `\src\JustEat.StatsD\JustEat.StatsD.csproj` to `System.Diagnostics.TraceSource` `4.3.0` from `4.0.0`
This is an automated update. Merge only if it passes tests

**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
